### PR TITLE
Add udev rules disabling wakeup on i2c devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ The BIOS [Menu Tree](https://cryptpad.fr/code/#/2/code/view/eYbhlShJI4118DQ0Qm-d
     echo disabled > /sys/bus/i2c/devices/i2c-GXTP7385:00/power/wakeup
     echo disabled > /sys/bus/i2c/devices/i2c-PNP0C50:00/power/wakeup
    ```
+   This can be done on boot by placing the following in `/etc/udev/rules.d/20-wm2-i2c-nowake.rules`:
+   ```
+   SUBSYSTEM=="i2c", KERNEL=="i2c-PNP0C50:00", ATTR{power/wakeup}="disabled"
+   SUBSYSTEM=="i2c", KERNEL=="i2c-GXTP7385:00", ATTR{power/wakeup}="disabled"
+   ```
 
 # Workarounds
 ###### SD card slots disconneting constantly workaround, credits to ciphray#8122 on discord for the workaround, credits to Xryptic#5251 on discord for the instructions.<br/>


### PR DESCRIPTION
udev is a standard way of setting up these things to happen automatically.